### PR TITLE
Fix undefined variables in wow64 exception context

### DIFF
--- a/src/exception/win32/context.cpp
+++ b/src/exception/win32/context.cpp
@@ -27,13 +27,13 @@ Win32StackWalkContext::Win32StackWalkContext(Win32ExceptionContext& exception_co
 
 #ifdef _WIN64
     BOOL wow64 = FALSE;
-    IsWow64Process(hProcess, &wow64);
+    IsWow64Process(exception_context.process, &wow64);
     if (wow64)
     {
         machine_type = IMAGE_FILE_MACHINE_I386;
         ZeroMemory(&wow64context, sizeof(wow64context));
         wow64context.ContextFlags = WOW64_CONTEXT_FULL;
-        if (!Wow64GetThreadContext(thread, &wow64context))
+        if (!Wow64GetThreadContext(exception_context.thread, &wow64context))
             return;
         context_ptr = (PCONTEXT)&wow64context;
         stack_frame.AddrPC.Offset = wow64context.Eip;

--- a/src/exception/win32/unhandled.cpp
+++ b/src/exception/win32/unhandled.cpp
@@ -33,7 +33,7 @@ static LONG WINAPI win32UnhandledExceptionHandler(PEXCEPTION_POINTERS ex_info)
     info.base_report = "Exception: ";
     info.base_report += exceptionCodeToString(ex_info->ExceptionRecord->ExceptionCode);
     info.base_report += " at 0x";
-    info.base_report += string::hex((int)ex_info->ExceptionRecord->ExceptionAddress);
+    info.base_report += string::hex((uintptr_t)ex_info->ExceptionRecord->ExceptionAddress);
     if (ex_info->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION || ex_info->ExceptionRecord->ExceptionCode == EXCEPTION_IN_PAGE_ERROR)
     {
         if (ex_info->ExceptionRecord->NumberParameters >= 2)


### PR DESCRIPTION
When compiling Geronimo on Windows using MinGW-w64, I got the following error:

    [ 76%] Building CXX object CMakeFiles/Geronimo.dir/C_/Persoonlijk/Projecten/SeriousProton2/src/exception/win32/context.cpp.obj
    C:\Persoonlijk\Projecten\SeriousProton2\src\exception\win32\context.cpp: In constructor 'sp::exception::Win32StackWalkContext::Win32StackWalkContext(sp::exception::Win32ExceptionContext&)':
    C:\Persoonlijk\Projecten\SeriousProton2\src\exception\win32\context.cpp:30:20: error: 'hProcess' was not declared in this scope
         IsWow64Process(hProcess, &wow64);
                        ^~~~~~~~
    C:\Persoonlijk\Projecten\SeriousProton2\src\exception\win32\context.cpp:30:20: note: suggested alternative: 'OpenProcess'
         IsWow64Process(hProcess, &wow64);
                        ^~~~~~~~
                        OpenProcess
    C:\Persoonlijk\Projecten\SeriousProton2\src\exception\win32\context.cpp:36:36: error: 'thread' was not declared in this scope
             if (!Wow64GetThreadContext(thread, &wow64context))
                                        ^~~~~~
    C:\Persoonlijk\Projecten\SeriousProton2\src\exception\win32\context.cpp:36:36: note: suggested alternative: '_hread'
             if (!Wow64GetThreadContext(thread, &wow64context))
                                        ^~~~~~
                                        _hread
    mingw32-make[2]: *** [CMakeFiles\Geronimo.dir\build.make:539: CMakeFiles/Geronimo.dir/C_/Persoonlijk/Projecten/SeriousProton2/src/exception/win32/context.cpp.obj] Error 1
    mingw32-make[1]: *** [CMakeFiles\Makefile2:299: CMakeFiles/Geronimo.dir/all] Error 2
    mingw32-make: *** [Makefile:151: all] Error 2

It seems that these undefined variables need to be obtained from the context in the parameter, though I have little idea of how they work. It compiles now, but did I get that right?