### PR TITLE
Fix ambiguity of std::abs call

### DIFF
--- a/src/graphics/image/hq2x.cpp
+++ b/src/graphics/image/hq2x.cpp
@@ -29,7 +29,7 @@ static bool diff(uint32_t color0, uint32_t color1)
     return (abs((yuv0 & 0xff0000) - (yuv1 & 0xff0000)) > trY)
         || (abs((yuv0 & 0x00ff00) - (yuv1 & 0x00ff00)) > trU)
         || (abs((yuv0 & 0x0000ff) - (yuv1 & 0x0000ff)) > trV)
-        || (std::abs((color0 >> 24) - (color1 >> 24)) > trA);
+        || (std::abs((short)((color0 >> 24) - (color1 >> 24))) > trA);
 }
 
 static inline uint32_t mix(uint32_t w1, uint32_t w2, uint32_t c1, uint32_t c2)

--- a/src/graphics/image/hq2x.cpp
+++ b/src/graphics/image/hq2x.cpp
@@ -29,7 +29,7 @@ static bool diff(uint32_t color0, uint32_t color1)
     return (abs((yuv0 & 0xff0000) - (yuv1 & 0xff0000)) > trY)
         || (abs((yuv0 & 0x00ff00) - (yuv1 & 0x00ff00)) > trU)
         || (abs((yuv0 & 0x0000ff) - (yuv1 & 0x0000ff)) > trV)
-        || (std::abs((short)((color0 >> 24) - (color1 >> 24))) > trA);
+        || (std::abs((int)((color0 >> 24) - (color1 >> 24))) > trA);
 }
 
 static inline uint32_t mix(uint32_t w1, uint32_t w2, uint32_t c1, uint32_t c2)


### PR DESCRIPTION
MinGW was giving an error on this code because it didn't know what version of std::abs to call with uint32_t:

    [ 75%] Building CXX object CMakeFiles/Geronimo.dir/C_/Persoonlijk/Projecten/SeriousProton2/src/graphics/image/hq2x.cpp.obj
    C:\Persoonlijk\Projecten\SeriousProton2\src\graphics\image\hq2x.cpp: In function 'bool sp::image::diff(uint32_t, uint32_t)':
    C:\Persoonlijk\Projecten\SeriousProton2\src\graphics\image\hq2x.cpp:32:53: error: call of overloaded 'abs(uint32_t)' is ambiguous
             || (std::abs((color0 >> 24) - (color1 >> 24)) > trA);
                                                         ^
    In file included from C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/cstdlib:77,
                     from C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/stdlib.h:36,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/string.h:4,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/graphics/image.h:4,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/graphics/image/hq2x.h:4,
                     from C:\Persoonlijk\Projecten\SeriousProton2\src\graphics\image\hq2x.cpp:1:
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:56:3: note: candidate: 'long int std::abs(long int)'
       abs(long __i) { return __builtin_labs(__i); }
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:61:3: note: candidate: 'long long int std::abs(long long int)'
       abs(long long __x) { return __builtin_llabs (__x); }
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:70:3: note: candidate: 'constexpr double std::abs(double)'
       abs(double __x)
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:74:3: note: candidate: 'constexpr float std::abs(float)'
       abs(float __x)
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:78:3: note: candidate: 'constexpr long double std::abs(long double)'
       abs(long double __x)
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:84:3: note: candidate: 'constexpr __int128 std::abs(__int128)'
       abs(__GLIBCXX_TYPE_INT_N_0 __x) { return __x >= 0 ? __x : -__x; }
       ^~~
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/bits/std_abs.h:102:3: note: candidate: 'constexpr __float128 std::abs(__float128)'
       abs(__float128 __x)
       ^~~
    In file included from C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/cstdlib:75,
                     from C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/stdlib.h:36,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/string.h:4,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/graphics/image.h:4,
                     from C:/Persoonlijk/Projecten/SeriousProton2/include/sp2/graphics/image/hq2x.h:4,
                     from C:\Persoonlijk\Projecten\SeriousProton2\src\graphics\image\hq2x.cpp:1:
    C:/PROGRA~1/MINGW-~1/X86_64~4.0-P/mingw64/x86_64-w64-mingw32/include/stdlib.h:383:15: note: candidate: 'int abs(int)'
       int __cdecl abs(int _X);
                   ^~~
    mingw32-make[2]: *** [CMakeFiles\Geronimo.dir\build.make:903: CMakeFiles/Geronimo.dir/C_/Persoonlijk/Projecten/SeriousProton2/src/graphics/image/hq2x.cpp.obj] Error 1
    mingw32-make[1]: *** [CMakeFiles\Makefile2:299: CMakeFiles/Geronimo.dir/all] Error 2
    mingw32-make: *** [Makefile:151: all] Error 2

I'm going out on a limb here to say that because we're right-shifting this integer by 24 bits, it's got to be able to fit inside a short. So short should be sufficient.